### PR TITLE
Update lavalink youtube-plugin version

### DIFF
--- a/lib/lavalink-conf.yml
+++ b/lib/lavalink-conf.yml
@@ -26,7 +26,7 @@ plugins:
 lavalink:
   plugins:
     # Replace VERSION with the current version as shown by the Releases tab or a long commit hash for snapshots.
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.11.4"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.3"
       repository: "https://maven.lavalink.dev/releases" # use https://maven.lavalink.dev/snapshots if you want to use a snapshot version.
   server:
     password: "admin"


### PR DESCRIPTION
Set to [latest version](https://github.com/lavalink-devs/youtube-source/releases/tag/1.13.3) due to `1.11.4` failing to extract cipher functions from updated youtube scripts 
```
Caused by: java.lang.IllegalStateException: Must find action functions from script: /s/player/e12fbea4/player_ias.vflset/hr_HR/base.js  
    at dev.lavalink.youtube.cipher.SignatureCipherManager.extractFromScript(SignatureCipherManager.java:252)  
    at dev.lavalink.youtube.cipher.SignatureCipherManager.getCipherScript(SignatureCipherManager.java:212)
```